### PR TITLE
Update Node version and add deployment step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           cache: 'yarn'
 
       - name: Install dependencies
@@ -33,3 +33,9 @@ jobs:
 
       - name: Build
         run: yarn build
+
+      - name: Deploy
+        uses: actions/deploy-pages@v4
+        with:
+          branch: gh-pages
+          folder: apps/web/build


### PR DESCRIPTION
Updated the Node.js version used in the GitHub Actions workflow from version 18 to version 20. Also added a new step in the workflow to deploy the application to the gh-pages branch using the deploy-pages@v4 action after the project build.