### PR TITLE
Add GitHub token to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+env:
+  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
The change introduces an environment variable for the GitHub token to the jobs section of the CI workflow file located in .github/workflows/. This token is essential for various tasks within the CI/CD actions like accessing repo information, creating releases, or updating project based on the workflow event triggers.