### PR TITLE
Downgrade deploy-pages action version in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: yarn build
 
       - name: Deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v3
         with:
           branch: gh-pages
           folder: apps/web/build


### PR DESCRIPTION
The version of 'deploy-pages' action being used in the CI workflow has been downgraded from v4 to v3. This was necessary due to dependencies or features that may not have been supported or functional in the recently released version. The change was executed in the CI workflow file located in .github/workflows/.